### PR TITLE
Fix code formatting in some files

### DIFF
--- a/code-examples/Aggregate user controls.rb
+++ b/code-examples/Aggregate user controls.rb
@@ -1,6 +1,6 @@
 # Aggregate user controls
 
-# First of all, you have to know that Devise gem is AUTHENTICATION gem, not AUTHORIZATION. 
+# First of all, you have to know that Devise gem is AUTHENTICATION gem, not AUTHORIZATION.
 # Using "before_action" in specific controllers will provide only authentication.
 
 # It is recommended to use authorization gem like Pundit over creating your own code
@@ -20,11 +20,11 @@
 	  end
 
 	  def update?
-	    user.admin? or not post.published?
+	    user.admin? || !post.published?
 	  end
 	end
 
-	#Controller authorization example
+	# Controller authorization example
 	def admin_list
 	  authorize Post # we don't have a particular post to authorize
 	  # Rest of controller action

--- a/code-examples/Anti caching headers.rb
+++ b/code-examples/Anti caching headers.rb
@@ -1,10 +1,10 @@
-#Anti caching headers
+# Anti caching headers
 
-#Example:
+# Example:
 
-#Add the following code to APP_DIR/config/environments/production.rb in order to prevent the browser from caching
+# Add the following code to APP_DIR/config/environments/production.rb in order to prevent the browser from caching
 
 config.action_controller.perform_caching = false
 config.public_file_server.headers = {
-	"Pragma" => "no-cache" #HTTP 1.0
- }
+  'Pragma' => 'no-cache' # HTTP 1.0
+}

--- a/code-examples/Anti clickjacking headers.rb
+++ b/code-examples/Anti clickjacking headers.rb
@@ -1,18 +1,18 @@
-#Anti clickjacking headers
+# Anti clickjacking headers
 
-#Example:
+# Example:
 
-#Ruby on Rails sets X-Frame-Options header with "SAMEORIGIN" option by default. 
-#If in your case it doesn't or you want to enforce "DENY" options, you can add that headers manually.
+# Ruby on Rails sets X-Frame-Options header with "SAMEORIGIN" option by default.
+# If in your case it doesn't or you want to enforce "DENY" options, you can add that headers manually.
 
-#Add the following code to APP_DIR/config/environments/production.rb
+# Add the following code to APP_DIR/config/environments/production.rb
 
 config.action_dispatch.default_headers = {
-  'X-Frame-Options' => "DENY" # this will completely prevent your page from being displayed in an iframe.
+  'X-Frame-Options' => 'DENY' # this will completely prevent your page from being displayed in an iframe.
 }
 
-# OR 
+# OR
 
 config.action_dispatch.default_headers = {
-  'X-Frame-Options' => "SAMEORIGIN" # this will completely prevent your page from being displayed in an iframe on other sites.
+  'X-Frame-Options' => 'SAMEORIGIN' # this will completely prevent your page from being displayed in an iframe on other sites.
 }

--- a/code-examples/Charsets.rb
+++ b/code-examples/Charsets.rb
@@ -1,10 +1,10 @@
-#X-XSS-Protection header
+# X-XSS-Protection header
 
-#Example:
+# Example:
 
-#Ruby on Rails sets encoding header with "utf-8" option by default. 
-#If in your case it doesn't or you want to set different encoding, you can do it manually.
+# Ruby on Rails sets encoding header with "utf-8" option by default.
+# If in your case it doesn't or you want to set different encoding, you can do it manually.
 
-#Add the following code to APP_DIR/config/environments/production.rb
+# Add the following code to APP_DIR/config/environments/production.rb
 
-config.encoding = "utf-8"
+config.encoding = 'utf-8'

--- a/code-examples/Content Type Headers.rb
+++ b/code-examples/Content Type Headers.rb
@@ -1,21 +1,19 @@
-#X-Content-Type header
+# X-Content-Type header
 
-#Example:
+# Example:
 
-#Ruby on Rails sets X-Content-Type-Options header with "nosniff" option by default. 
-#If in your case it doesn't, you can add the header manually.
+# Ruby on Rails sets X-Content-Type-Options header with "nosniff" option by default.
+# If in your case it doesn't, you can add the header manually.
 
-#Add the following code to APP_DIR/app/controllers/YOUR_CONTROLLER.rb
+# Add the following code to APP_DIR/app/controllers/YOUR_CONTROLLER.rb
 
-class YOUR_CONTROLLER < ApplicationController
-
+class YourController < ApplicationController
   def rendering_inline
-  	render inline: "Content of the file", content_type: "application/foo"
+    render inline: 'Content of the file', content_type: 'application/foo'
   end
 
   def rendering_from_file
-  	render file: filename, content_type: "application/foo"
+    render file: filename, content_type: 'application/foo'
   end
-
 end
 

--- a/code-examples/White listing.rb
+++ b/code-examples/White listing.rb
@@ -3,12 +3,13 @@
 # Example
 
 def check_pattern(param, list = [])
-        # List should be an array of allowed patterns
-        # list = ["value1", "value2"]
-        if list.include? param
-                Rails.logger.info "#{session.id} -> Good whitelist validation"
-                return true
-        end
-        Rails.logger.warn "#{session.id} -> Bad whitelist validation"
-        return false
+  # List should be an array of allowed patterns
+  # list = ["value1", "value2"]
+  if list.include? param
+    Rails.logger.info "#{session.id} -> Good whitelist validation"
+    true
+  else
+    Rails.logger.warn "#{session.id} -> Bad whitelist validation"
+    false
+  end
 end

--- a/code-examples/X Content Type Options header.rb
+++ b/code-examples/X Content Type Options header.rb
@@ -1,12 +1,12 @@
-#X-Content-Type-Options header
+# X-Content-Type-Options header
 
-#Example:
+# Example:
 
-#Ruby on Rails sets X-Content-Type-Options header with "nosniff" option by default. 
-#If in your case it doesn't, you can add the header manually.
+# Ruby on Rails sets X-Content-Type-Options header with "nosniff" option by default.
+# If in your case it doesn't, you can add the header manually.
 
-#Add the following code to APP_DIR/config/environments/production.rb
+# Add the following code to APP_DIR/config/environments/production.rb
 
 config.action_dispatch.default_headers = {
-  'X-Content-Type-Options' => "nosniff"
+  'X-Content-Type-Options' => 'nosniff'
 }

--- a/code-examples/X XSS Protection header.rb
+++ b/code-examples/X XSS Protection header.rb
@@ -1,12 +1,12 @@
-#X-XSS-Protection header
+# X-XSS-Protection header
 
-#Example:
+# Example:
 
-#Ruby on Rails sets X-XSS-Protection header with "1; mode=block" option by default. 
-#If in your case it doesn't, you can add the header manually.
+# Ruby on Rails sets X-XSS-Protection header with "1; mode=block" option by default.
+# If in your case it doesn't, you can add the header manually.
 
-#Add the following code to APP_DIR/config/environments/production.rb
+# Add the following code to APP_DIR/config/environments/production.rb
 
 config.action_dispatch.default_headers = {
-  'X-XSS-Protection' => "1; mode=block"
+  'X-XSS-Protection' => '1; mode=block'
 }

--- a/code-examples/XML External entities.rb
+++ b/code-examples/XML External entities.rb
@@ -1,8 +1,8 @@
 # XML External entities
 
-# Typically parsing XML files is done by using external gems like Nokogiri. In the Nokogiri using external entities
+# Typically parsing XML files is done by using external gems like Nokogiri. In Nokogiri using external entities
 # is turned off by default. Always check it in the documentation. If you want to be sure - turn off parsing external
-# entities explicite.
+# entities explicitly.
 
 # Example of turning off parsing external entities in Nokogiri gem
 require 'nokogiri'

--- a/code-examples/XML injection prevention.rb
+++ b/code-examples/XML injection prevention.rb
@@ -12,11 +12,11 @@
 # your own function for achieving this. See the code examples and search for "Input encoding"
 # for more detailed information.
 
-require "Nokogiri"
+require 'nokogiri'
 
-xml_doc  = Nokogiri::XML("<employees><employee><name></name></employee></employees>")
+xml_doc = Nokogiri::XML('<employees><employee><name></name></employee></employees>')
 
-xml_doc.css("employees employee name").first.content = params[:name]
+xml_doc.css('employees employee name').first.content = params[:name]
 
 # In Nokogiri gem HTML Encoding is done by default. Printing xml_doc.to_xml should return
 # => "<?xml version=\"1.0\"?>\n<employees>\n  <employee>\n    <name>&lt;script&gt;alert(\"1\")&lt;/script&gt;</name>\n  </employee>\n</employees>\n"

--- a/code-examples/XSL injection prevention.rb
+++ b/code-examples/XSL injection prevention.rb
@@ -13,22 +13,19 @@
 # defined files, example:
 # check_pattern(params[:xslfile], "file1.xsl,file2.xsl,etc")
 
-require "Nokogiri"
+require 'nokogiri'
 
 # Include the classes of which you want to use objects from
-require_relative "classes"
+require_relative 'classes'
 
-class includeXSL
+class IncludeXSL
+  def including(param, white_list)
+    # check "Whitelisting" for method declaration
+    if check_pattern(param, white_list)
+      document = Nokogiri::XML(File.read('input.xml'))
+      template = Nokogiri::XSLT(File.read('template.xslt'))
 
-	def including(param, white_list)
-
-		# check "Whitelisting" for method declaration
-		if check_pattern(param, white_list)
-			document = Nokogiri::XML(File.read('input.xml'))
-			template = Nokogiri::XSLT(File.read('template.xslt'))
-
-			transformed_document = template.transform(document)
-		end
-
-	end
+      transformed_document = template.transform(document)
+    end
+  end
 end


### PR DESCRIPTION
These are mostly minor changes:

- tabs -> spaces
- `or not` -> `|| !`
- double quotes -> single quotes